### PR TITLE
feat(cfprobe): 增加时间校准并修正上报时间戳

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ Agent 会按 `REPORT_INTERVAL` 向 `WORKER_URL` 发起 `POST` 请求，`Content-
 {
   "id": "SERVER_ID",
   "secret": "SECRET",
+  "time": {
+    "local_ts": 1754300060123,
+    "accurate_ts": 1754300060000,
+    "offset_ms": -123,
+    "source": "ntp:time.cloudflare.com",
+    "round_trip_ms": 18,
+    "sample_age_ms": 29982
+  },
   "metrics": {
     "cpu": "0.00",
     "ram_total": "0",
@@ -280,10 +288,26 @@ Agent 会按 `REPORT_INTERVAL` 向 `WORKER_URL` 发起 `POST` 请求，`Content-
 | --- | --- | --- |
 | `id` | string | 服务器 ID，对应本地 `SERVER_ID` |
 | `secret` | string | 服务器密钥，对应本地 `SECRET` |
+| `time` | object | 本机墙钟与独立时间校准状态；字段见下表 |
 | `metrics` | object | 当前上报周期的完整监控指标 |
 | `samples` | array | 可选，仅 `COLLECT_INTERVAL > 0` 时存在 |
 | `collect_interval` | number | 高频采样间隔，单位秒；`0` 表示不启用高频采样 |
 | `report_interval` | number | 上报间隔，单位秒 |
+
+`time` 字段：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `local_ts` | number | 本次组包时的本机 Unix 毫秒墙钟 |
+| `accurate_ts` | number/null | 根据最近一次 NTP 或 Worker 时间样本，以单调时钟推算的 Unix 毫秒时间；首次校准前为 `null` |
+| `offset_ms` | number/null | `accurate_ts - local_ts`；正数表示本机慢，负数表示本机快 |
+| `source` | string/null | 优先为 `ntp:<host>`；公共 NTP 不可用而 Worker 提供时间时为 `server` |
+| `round_trip_ms` | number/null | 最近一次成功校准请求的往返耗时 |
+| `sample_age_ms` | number/null | 最近校准样本到本次组包的单调时钟年龄 |
+
+Agent 每 10 分钟并行查询 `time.cloudflare.com`、`time.google.com`、`time.nist.gov` 和 `ntp.aliyun.com`，按成功样本的偏差中位数选择来源，校准样本最长使用 24 小时。准确时间锚定在单调时钟上推进，因此校准后即使本机墙钟跳变，下一次上报的 `offset_ms` 也会立即反映；Agent 不修改系统时间，也不改写已采集的 `samples[].ts`。
+
+公共 NTP 不可用时，Worker 可以在成功响应中返回尽量靠近响应发送时刻生成的 Unix 毫秒 `server_time`。现有 URL 编码响应可直接追加 `server_time=1754300060011`；无配置响应也可返回 `{"server_time":1754300060011}`，或设置 `X-Server-Time: 1754300060011`。Agent 会结合本次请求 RTT 推算兜底时间，旧 Worker 无需修改也仍然兼容。
 
 `metrics` 字段：
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Agent 会按 `REPORT_INTERVAL` 向 `WORKER_URL` 发起 `POST` 请求，`Content-
 | `round_trip_ms` | number/null | 最近一次成功校准请求的往返耗时 |
 | `sample_age_ms` | number/null | 最近校准样本到本次组包的单调时钟年龄 |
 
-Agent 每 10 分钟并行查询 `time.cloudflare.com`、`time.google.com`、`time.nist.gov` 和 `ntp.aliyun.com`，按成功样本的偏差中位数选择来源，校准样本最长使用 24 小时。准确时间锚定在单调时钟上推进，因此校准后即使本机墙钟跳变，下一次上报的 `offset_ms` 也会立即反映；Agent 不修改系统时间，也不改写已采集的 `samples[].ts`。
+Agent 每 10 分钟并行查询 `time.cloudflare.com`、`time.google.com`、`time.nist.gov` 和 `ntp.aliyun.com`，按成功样本的偏差中位数选择来源，校准样本最长使用 24 小时。准确时间锚定在单调时钟上推进，因此校准后即使本机墙钟跳变，下一次上报的 `offset_ms` 也会立即反映。上报前会用同一锚点换算 `samples[].ts`，并校正 `metrics.boot_time`；本轮 NTP 完成前采集的待上报样本也会按单调时间回算。Agent 不修改系统时间。
 
 公共 NTP 不可用时，Worker 可以在成功响应中返回尽量靠近响应发送时刻生成的 Unix 毫秒 `server_time`。现有 URL 编码响应可直接追加 `server_time=1754300060011`；无配置响应也可返回 `{"server_time":1754300060011}`，或设置 `X-Server-Time: 1754300060011`。Agent 会结合本次请求 RTT 推算兜底时间，旧 Worker 无需修改也仍然兼容。
 

--- a/internal/cfprobe/agent.go
+++ b/internal/cfprobe/agent.go
@@ -33,6 +33,7 @@ type Agent struct {
 	prevTime   time.Time
 	prevDisk   DiskIOCounters
 	prevDiskAt time.Time
+	clock      calibratedClock
 
 	samples    []map[string]any
 	lastReport time.Time
@@ -54,6 +55,11 @@ type timedProbeResult struct {
 type rollingProbeHistory struct {
 	target  string
 	samples []timedProbeResult
+}
+
+type ntpRefreshResult struct {
+	sample ntpSample
+	err    error
 }
 
 func (h *rollingProbeHistory) add(now time.Time, target string, result ProbeResult) {
@@ -313,6 +319,7 @@ func (a *Agent) report(m Metrics) {
 	payload := map[string]any{
 		"id":               a.cfg.ServerID,
 		"secret":           a.cfg.Secret,
+		"time":             a.clock.snapshot(time.Now()),
 		"metrics":          metricsToMap(m),
 		"collect_interval": a.cfg.CollectInterval,
 		"report_interval":  a.cfg.ReportInterval,
@@ -324,6 +331,10 @@ func (a *Agent) report(m Metrics) {
 	if err != nil {
 		a.log.warnf("marshal payload failed: %v", err)
 		return
+	}
+	ntpResult := a.startNTPRefresh()
+	if ntpResult != nil {
+		defer a.finishNTPRefresh(ntpResult)
 	}
 	gpuSummary, _ := json.Marshal(m.GPUInfo)
 	a.log.debugf("metrics summary cpu=%s gpu_info=%s", m.CPU, string(gpuSummary))
@@ -339,6 +350,7 @@ func (a *Agent) report(m Metrics) {
 	req.Header.Set("X-Agent-Version", a.version)
 	req.Header.Set("X-Agent-Config-Md5", firstNonEmpty(a.cfg.ConfigMD5, "none"))
 
+	started := time.Now()
 	resp, err := sharedReportHTTPClient(8*time.Second, usePublicDNSResolver(a.cfg)).Do(req)
 	if err != nil {
 		a.log.warnf("report failed: %v", err)
@@ -346,24 +358,75 @@ func (a *Agent) report(m Metrics) {
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+	completed := time.Now()
 	respHeaders := resp.Header
 	reportHTTPCode := resp.StatusCode
-	a.handleReportResponse(reportHTTPCode, respBody, respHeaders)
+	a.handleTimedReportResponse(reportHTTPCode, respBody, respHeaders, started, completed)
 }
 
 func (a *Agent) handleReportResponse(statusCode int, respBody []byte, headers http.Header) {
+	now := time.Now()
+	a.handleTimedReportResponse(statusCode, respBody, headers, now, now)
+}
+
+func (a *Agent) handleTimedReportResponse(statusCode int, respBody []byte, headers http.Header, started, completed time.Time) {
 	a.log.debugf("report response http=%d body=%s", statusCode, strings.TrimSpace(string(respBody)))
 	if statusCode < 200 || statusCode >= 300 {
 		return
 	}
-	if strings.EqualFold(strings.TrimSpace(string(respBody)), "OK") {
+	if serverTime, ok := responseServerTime(respBody, headers); ok {
+		snapshot := a.clock.updateServer(serverTime, completed.Sub(started), completed)
+		a.log.debugf("server fallback time calibrated offset_ms=%d round_trip_ms=%d",
+			valueOrZero(snapshot.OffsetMS), valueOrZero(snapshot.RoundTripMS))
+	}
+	rawBody := strings.TrimSpace(string(respBody))
+	if rawBody == "" || rawBody == "{}" || strings.EqualFold(rawBody, "OK") {
 		return
+	}
+	if strings.HasPrefix(rawBody, "{") {
+		var envelope map[string]json.RawMessage
+		if json.Unmarshal(respBody, &envelope) == nil {
+			delete(envelope, "server_time")
+			if len(envelope) == 0 {
+				return
+			}
+		}
 	}
 	if statusCode == http.StatusOK {
 		if err := a.applyRemoteConfig(respBody, headers); err != nil {
 			a.log.warnf("dynamic configuration rejected: %v", err)
 		}
 	}
+}
+
+func (a *Agent) startNTPRefresh() <-chan ntpRefreshResult {
+	if !a.clock.beginNTPRefresh(time.Now()) {
+		return nil
+	}
+	result := make(chan ntpRefreshResult, 1)
+	go func() {
+		sample, err := queryNTPServers(context.Background(), ntpServerHosts)
+		result <- ntpRefreshResult{sample: sample, err: err}
+	}()
+	return result
+}
+
+func (a *Agent) finishNTPRefresh(result <-chan ntpRefreshResult) {
+	refresh := <-result
+	if refresh.err != nil {
+		a.log.debugf("NTP calibration unavailable; Worker server_time remains the fallback: %v", refresh.err)
+		return
+	}
+	snapshot := a.clock.updateNTP(refresh.sample)
+	a.log.debugf("NTP time calibrated source=ntp:%s offset_ms=%d round_trip_ms=%d",
+		refresh.sample.server, valueOrZero(snapshot.OffsetMS), valueOrZero(snapshot.RoundTripMS))
+}
+
+func valueOrZero[T ~int64 | ~uint64](value *T) T {
+	if value == nil {
+		return 0
+	}
+	return *value
 }
 
 func (a *Agent) networkWorker(ctx context.Context) {
@@ -457,6 +520,7 @@ func (a *Agent) applyRemoteConfig(body []byte, headers http.Header) error {
 		"rx_correction":    true,
 		"tx_correction":    true,
 		"update":           true,
+		"server_time":      true,
 	}
 	for key := range values {
 		if !allowed[key] {
@@ -468,8 +532,18 @@ func (a *Agent) applyRemoteConfig(body []byte, headers http.Header) error {
 		return fmt.Errorf("invalid update %s", update)
 	}
 	hasConfig := values.Has("collect_interval") || values.Has("report_interval") || values.Has("reset_day") || values.Has("schema_version") || values.Has("interface")
+	hasCorrection := values.Has("rx_correction") || values.Has("tx_correction")
 	if !hasConfig {
-		if values.Has("update") {
+		if hasCorrection {
+			rx := values.Get("rx_correction")
+			tx := values.Get("tx_correction")
+			if err := applyTrafficCorrection(a.paths.TrafficFile, readNetBytes(a.cfg.Interface), a.cfg.Interface, rx, tx); err != nil {
+				return err
+			}
+			_ = a.sendCorrectionConfirm(rx, tx)
+			return nil
+		}
+		if values.Has("update") || values.Has("server_time") {
 			return nil
 		}
 		return errors.New("no config fields")
@@ -524,7 +598,7 @@ func (a *Agent) applyRemoteConfig(body []byte, headers http.Header) error {
 		a.lastReport = time.Time{}
 		a.log.info("dynamic configuration applied md5=%s interface=%s", newMD5, firstNonEmpty(iface, "auto"))
 	}
-	if values.Has("rx_correction") || values.Has("tx_correction") {
+	if hasCorrection {
 		rx := values.Get("rx_correction")
 		tx := values.Get("tx_correction")
 		if err := applyTrafficCorrection(a.paths.TrafficFile, readNetBytes(a.cfg.Interface), a.cfg.Interface, rx, tx); err != nil {

--- a/internal/cfprobe/agent.go
+++ b/internal/cfprobe/agent.go
@@ -35,7 +35,7 @@ type Agent struct {
 	prevDiskAt time.Time
 	clock      calibratedClock
 
-	samples    []map[string]any
+	samples    []metricSample
 	lastReport time.Time
 	updateMu   sync.Mutex
 }
@@ -60,6 +60,11 @@ type rollingProbeHistory struct {
 type ntpRefreshResult struct {
 	sample ntpSample
 	err    error
+}
+
+type metricSample struct {
+	at      time.Time
+	metrics map[string]any
 }
 
 func (h *rollingProbeHistory) add(now time.Time, target string, result ProbeResult) {
@@ -225,9 +230,9 @@ func (a *Agent) tick() {
 	}
 	m := a.buildMetrics(cpu, netNow, rxSpeed, txSpeed, rxMonthly, txMonthly, diskIO)
 	if a.cfg.CollectInterval > 0 {
-		a.samples = append(a.samples, map[string]any{
-			"ts":      now.UnixMilli(),
-			"metrics": sampleMetricsToMap(m),
+		a.samples = append(a.samples, metricSample{
+			at:      now,
+			metrics: sampleMetricsToMap(m),
 		})
 	}
 	if shouldReport {
@@ -316,25 +321,25 @@ func probeLossValue(node string, r ProbeResult) any {
 }
 
 func (a *Agent) report(m Metrics) {
+	if ntpResult := a.startNTPRefresh(); ntpResult != nil {
+		a.finishNTPRefresh(ntpResult)
+	}
+	reportAt := time.Now()
 	payload := map[string]any{
 		"id":               a.cfg.ServerID,
 		"secret":           a.cfg.Secret,
-		"time":             a.clock.snapshot(time.Now()),
-		"metrics":          metricsToMap(m),
+		"time":             a.clock.snapshot(reportAt),
+		"metrics":          a.metricsForReport(m, reportAt),
 		"collect_interval": a.cfg.CollectInterval,
 		"report_interval":  a.cfg.ReportInterval,
 	}
 	if a.cfg.CollectInterval > 0 {
-		payload["samples"] = a.samples
+		payload["samples"] = a.samplesForReport()
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
 		a.log.warnf("marshal payload failed: %v", err)
 		return
-	}
-	ntpResult := a.startNTPRefresh()
-	if ntpResult != nil {
-		defer a.finishNTPRefresh(ntpResult)
 	}
 	gpuSummary, _ := json.Marshal(m.GPUInfo)
 	a.log.debugf("metrics summary cpu=%s gpu_info=%s", m.CPU, string(gpuSummary))
@@ -362,6 +367,27 @@ func (a *Agent) report(m Metrics) {
 	respHeaders := resp.Header
 	reportHTTPCode := resp.StatusCode
 	a.handleTimedReportResponse(reportHTTPCode, respBody, respHeaders, started, completed)
+}
+
+func (a *Agent) samplesForReport() []map[string]any {
+	samples := make([]map[string]any, 0, len(a.samples))
+	for _, sample := range a.samples {
+		timestamp, _ := a.clock.timestamp(sample.at)
+		samples = append(samples, map[string]any{
+			"ts":      timestamp,
+			"metrics": sample.metrics,
+		})
+	}
+	return samples
+}
+
+func (a *Agent) metricsForReport(m Metrics, reportAt time.Time) map[string]any {
+	metrics := metricsToMap(m)
+	bootTime, err := strconv.ParseInt(m.BootTime, 10, 64)
+	if err == nil && bootTime > 0 {
+		metrics["boot_time"] = strconv.FormatInt(a.clock.correctLocalTimestamp(bootTime, reportAt), 10)
+	}
+	return metrics
 }
 
 func (a *Agent) handleReportResponse(statusCode int, respBody []byte, headers http.Header) {

--- a/internal/cfprobe/clock.go
+++ b/internal/cfprobe/clock.go
@@ -98,7 +98,7 @@ func (c clockCalibration) snapshot(now time.Time) ReportTime {
 		age = 0
 	}
 	ageMS := durationMilliseconds(age)
-	accurateTS := addMilliseconds(c.accurateAtAnchor, ageMS)
+	accurateTS := c.timestamp(now)
 	localTS := now.UnixMilli()
 	offsetMS := saturatingSubtract(accurateTS, localTS)
 	source := c.source
@@ -113,28 +113,65 @@ func (c clockCalibration) snapshot(now time.Time) ReportTime {
 	}
 }
 
+func (c clockCalibration) timestamp(at time.Time) int64 {
+	deltaMilliseconds := int64(at.Sub(c.anchor) / time.Millisecond)
+	return saturatingAdd(c.accurateAtAnchor, deltaMilliseconds)
+}
+
 func (c *calibratedClock) snapshot(now time.Time) ReportTime {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var calibration *clockCalibration
-	if calibrationFresh(c.ntp, now) {
-		calibration = c.ntp
-	} else if calibrationFresh(c.server, now) {
-		calibration = c.server
-	}
+	calibration := c.calibrationAt(now, false)
 	if calibration == nil {
 		return ReportTime{LocalTS: now.UnixMilli()}
 	}
 	return calibration.snapshot(now)
 }
 
-func calibrationFresh(calibration *clockCalibration, now time.Time) bool {
+// timestamp maps an observation time onto the calibrated Unix timeline. A
+// fresh calibration may be used retroactively so samples collected shortly
+// before the NTP response can still be corrected before they are reported.
+func (c *calibratedClock) timestamp(at time.Time) (int64, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	calibration := c.calibrationAt(at, true)
+	if calibration == nil {
+		return at.UnixMilli(), false
+	}
+	return calibration.timestamp(at), true
+}
+
+// correctLocalTimestamp applies the calibrated offset at observedAt to an
+// absolute timestamp supplied by the local OS, such as boot_time.
+func (c *calibratedClock) correctLocalTimestamp(localTimestamp int64, observedAt time.Time) int64 {
+	accurateAt, ok := c.timestamp(observedAt)
+	if !ok {
+		return localTimestamp
+	}
+	offset := saturatingSubtract(accurateAt, observedAt.UnixMilli())
+	return saturatingAdd(localTimestamp, offset)
+}
+
+func (c *calibratedClock) calibrationAt(at time.Time, allowRetroactive bool) *clockCalibration {
+	if calibrationUsable(c.ntp, at, allowRetroactive) {
+		return c.ntp
+	}
+	if calibrationUsable(c.server, at, allowRetroactive) {
+		return c.server
+	}
+	return nil
+}
+
+func calibrationUsable(calibration *clockCalibration, at time.Time, allowRetroactive bool) bool {
 	if calibration == nil {
 		return false
 	}
-	age := now.Sub(calibration.anchor)
-	return age >= 0 && age <= maxCalibrationAge
+	age := at.Sub(calibration.anchor)
+	if age < 0 {
+		return allowRetroactive && age >= -maxCalibrationAge
+	}
+	return age <= maxCalibrationAge
 }
 
 func (c *calibratedClock) beginNTPRefresh(now time.Time) bool {
@@ -187,6 +224,16 @@ func saturatingSubtract(left, right int64) int64 {
 		return math.MaxInt64
 	}
 	return left - right
+}
+
+func saturatingAdd(left, right int64) int64 {
+	if right > 0 && left > math.MaxInt64-right {
+		return math.MaxInt64
+	}
+	if right < 0 && left < math.MinInt64-right {
+		return math.MinInt64
+	}
+	return left + right
 }
 
 func unixMillisecondsToNTPTimestamp(unixMilliseconds int64) [8]byte {

--- a/internal/cfprobe/clock.go
+++ b/internal/cfprobe/clock.go
@@ -1,0 +1,410 @@
+package cfprobe
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	ntpQueryTimeout      = 2 * time.Second
+	ntpRefreshInterval   = 10 * time.Minute
+	maxCalibrationAge    = 24 * time.Hour
+	ntpUnixEpochSeconds  = int64(2_208_988_800)
+	nanosecondsPerSecond = int64(time.Second)
+	nanosecondsPerMilli  = int64(time.Millisecond)
+	serverTimeHeader     = "X-Server-Time"
+)
+
+var ntpServerHosts = []string{
+	"time.cloudflare.com",
+	"time.google.com",
+	"time.nist.gov",
+	"ntp.aliyun.com",
+}
+
+// ReportTime describes the local wall clock and the latest independent clock
+// calibration. Pointer fields intentionally serialize as null before the first
+// successful calibration.
+type ReportTime struct {
+	LocalTS     int64   `json:"local_ts"`
+	AccurateTS  *int64  `json:"accurate_ts"`
+	OffsetMS    *int64  `json:"offset_ms"`
+	Source      *string `json:"source"`
+	RoundTripMS *uint64 `json:"round_trip_ms"`
+	SampleAgeMS *uint64 `json:"sample_age_ms"`
+}
+
+type calibratedClock struct {
+	mu             sync.Mutex
+	ntp            *clockCalibration
+	server         *clockCalibration
+	lastNTPAttempt time.Time
+}
+
+type clockCalibration struct {
+	source           string
+	anchor           time.Time
+	accurateAtAnchor int64
+	roundTripMS      uint64
+}
+
+type ntpSample struct {
+	server           string
+	anchor           time.Time
+	accurateAtAnchor int64
+	roundTripMS      uint64
+	offsetNanos      int64
+}
+
+func newServerCalibration(serverTime int64, roundTrip time.Duration, anchor time.Time) clockCalibration {
+	roundTripMS := durationMilliseconds(roundTrip)
+	// The Worker stamps server_time close to response transmission. With one
+	// server timestamp, half of the request RTT is the best available estimate
+	// of the response's remaining travel time.
+	halfRoundTrip := roundTripMS/2 + roundTripMS%2
+	return clockCalibration{
+		source:           "server",
+		anchor:           anchor,
+		accurateAtAnchor: addMilliseconds(serverTime, halfRoundTrip),
+		roundTripMS:      roundTripMS,
+	}
+}
+
+func newNTPCalibration(sample ntpSample) clockCalibration {
+	return clockCalibration{
+		source:           "ntp:" + sample.server,
+		anchor:           sample.anchor,
+		accurateAtAnchor: sample.accurateAtAnchor,
+		roundTripMS:      sample.roundTripMS,
+	}
+}
+
+func (c clockCalibration) snapshot(now time.Time) ReportTime {
+	age := now.Sub(c.anchor)
+	if age < 0 {
+		age = 0
+	}
+	ageMS := durationMilliseconds(age)
+	accurateTS := addMilliseconds(c.accurateAtAnchor, ageMS)
+	localTS := now.UnixMilli()
+	offsetMS := saturatingSubtract(accurateTS, localTS)
+	source := c.source
+	roundTripMS := c.roundTripMS
+	return ReportTime{
+		LocalTS:     localTS,
+		AccurateTS:  &accurateTS,
+		OffsetMS:    &offsetMS,
+		Source:      &source,
+		RoundTripMS: &roundTripMS,
+		SampleAgeMS: &ageMS,
+	}
+}
+
+func (c *calibratedClock) snapshot(now time.Time) ReportTime {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var calibration *clockCalibration
+	if calibrationFresh(c.ntp, now) {
+		calibration = c.ntp
+	} else if calibrationFresh(c.server, now) {
+		calibration = c.server
+	}
+	if calibration == nil {
+		return ReportTime{LocalTS: now.UnixMilli()}
+	}
+	return calibration.snapshot(now)
+}
+
+func calibrationFresh(calibration *clockCalibration, now time.Time) bool {
+	if calibration == nil {
+		return false
+	}
+	age := now.Sub(calibration.anchor)
+	return age >= 0 && age <= maxCalibrationAge
+}
+
+func (c *calibratedClock) beginNTPRefresh(now time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.lastNTPAttempt.IsZero() && now.Sub(c.lastNTPAttempt) < ntpRefreshInterval {
+		return false
+	}
+	c.lastNTPAttempt = now
+	return true
+}
+
+func (c *calibratedClock) updateNTP(sample ntpSample) ReportTime {
+	calibration := newNTPCalibration(sample)
+	snapshot := calibration.snapshot(time.Now())
+	c.mu.Lock()
+	c.ntp = &calibration
+	c.mu.Unlock()
+	return snapshot
+}
+
+func (c *calibratedClock) updateServer(serverTime int64, roundTrip time.Duration, anchor time.Time) ReportTime {
+	calibration := newServerCalibration(serverTime, roundTrip, anchor)
+	snapshot := calibration.snapshot(time.Now())
+	c.mu.Lock()
+	c.server = &calibration
+	c.mu.Unlock()
+	return snapshot
+}
+
+func durationMilliseconds(duration time.Duration) uint64 {
+	if duration <= 0 {
+		return 0
+	}
+	return uint64(duration / time.Millisecond)
+}
+
+func addMilliseconds(timestamp int64, milliseconds uint64) int64 {
+	if milliseconds > math.MaxInt64 || timestamp > math.MaxInt64-int64(milliseconds) {
+		return math.MaxInt64
+	}
+	return timestamp + int64(milliseconds)
+}
+
+func saturatingSubtract(left, right int64) int64 {
+	if right > 0 && left < math.MinInt64+right {
+		return math.MinInt64
+	}
+	if right < 0 && left > math.MaxInt64+right {
+		return math.MaxInt64
+	}
+	return left - right
+}
+
+func unixMillisecondsToNTPTimestamp(unixMilliseconds int64) [8]byte {
+	seconds := unixMilliseconds / 1000
+	milliseconds := unixMilliseconds % 1000
+	if milliseconds < 0 {
+		seconds--
+		milliseconds += 1000
+	}
+	ntpSeconds := uint32(seconds + ntpUnixEpochSeconds)
+	fraction := uint32((uint64(milliseconds) << 32) / 1000)
+	var encoded [8]byte
+	binary.BigEndian.PutUint32(encoded[:4], ntpSeconds)
+	binary.BigEndian.PutUint32(encoded[4:], fraction)
+	return encoded
+}
+
+func ntpTimestampToUnixNanoseconds(timestamp []byte) (int64, error) {
+	if len(timestamp) != 8 {
+		return 0, errors.New("invalid NTP timestamp length")
+	}
+	seconds := binary.BigEndian.Uint32(timestamp[:4])
+	fraction := binary.BigEndian.Uint32(timestamp[4:])
+	if seconds == 0 && fraction == 0 {
+		return 0, errors.New("empty NTP timestamp")
+	}
+	unixSeconds := int64(seconds) - ntpUnixEpochSeconds
+	fractionNanos := int64(uint64(fraction) * uint64(nanosecondsPerSecond) >> 32)
+	return unixSeconds*nanosecondsPerSecond + fractionNanos, nil
+}
+
+func queryNTPServers(ctx context.Context, servers []string) (ntpSample, error) {
+	if len(servers) == 0 {
+		return ntpSample{}, errors.New("no NTP servers configured")
+	}
+	type result struct {
+		sample ntpSample
+		err    error
+	}
+	results := make(chan result, len(servers))
+	for _, server := range servers {
+		server := server
+		go func() {
+			sample, err := queryNTPServer(ctx, server)
+			results <- result{sample: sample, err: err}
+		}()
+	}
+
+	samples := make([]ntpSample, 0, len(servers))
+	for range servers {
+		result := <-results
+		if result.err == nil {
+			samples = append(samples, result.sample)
+		}
+	}
+	if len(samples) == 0 {
+		return ntpSample{}, errors.New("all NTP queries failed")
+	}
+	return selectMedianNTPSample(samples), nil
+}
+
+func selectMedianNTPSample(samples []ntpSample) ntpSample {
+	sort.Slice(samples, func(i, j int) bool {
+		return samples[i].offsetNanos < samples[j].offsetNanos
+	})
+	middle := len(samples) / 2
+	median := samples[middle].offsetNanos
+	if len(samples)%2 == 0 {
+		lower := samples[middle-1].offsetNanos
+		median = lower + (median-lower)/2
+	}
+	selected := 0
+	for index := 1; index < len(samples); index++ {
+		selectedDistance := absoluteDifference(samples[selected].offsetNanos, median)
+		candidateDistance := absoluteDifference(samples[index].offsetNanos, median)
+		if candidateDistance < selectedDistance ||
+			(candidateDistance == selectedDistance && samples[index].roundTripMS < samples[selected].roundTripMS) {
+			selected = index
+		}
+	}
+	return samples[selected]
+}
+
+func absoluteDifference(left, right int64) uint64 {
+	if left >= right {
+		return uint64(left) - uint64(right)
+	}
+	return uint64(right) - uint64(left)
+}
+
+func queryNTPServer(parent context.Context, server string) (ntpSample, error) {
+	ctx, cancel := context.WithTimeout(parent, ntpQueryTimeout)
+	defer cancel()
+	addresses, err := net.DefaultResolver.LookupIPAddr(ctx, server)
+	if err != nil {
+		return ntpSample{}, fmt.Errorf("resolve NTP server %s: %w", server, err)
+	}
+	if len(addresses) == 0 {
+		return ntpSample{}, fmt.Errorf("NTP server %s has no addresses", server)
+	}
+	selected := addresses[0].IP
+	for _, address := range addresses {
+		if address.IP.To4() != nil {
+			selected = address.IP
+			break
+		}
+	}
+	return queryNTPAddress(ctx, server, &net.UDPAddr{IP: selected, Port: 123})
+}
+
+func queryNTPAddress(ctx context.Context, server string, address *net.UDPAddr) (ntpSample, error) {
+	connection, err := net.DialUDP("udp", nil, address)
+	if err != nil {
+		return ntpSample{}, fmt.Errorf("connect NTP server %s: %w", server, err)
+	}
+	defer connection.Close()
+	deadline := time.Now().Add(ntpQueryTimeout)
+	if contextDeadline, ok := ctx.Deadline(); ok && contextDeadline.Before(deadline) {
+		deadline = contextDeadline
+	}
+	if err := connection.SetDeadline(deadline); err != nil {
+		return ntpSample{}, fmt.Errorf("set NTP deadline: %w", err)
+	}
+
+	started := time.Now()
+	localStarted := started.UnixMilli()
+	request := make([]byte, 48)
+	request[0] = 0x23 // leap=0, version=4, mode=3 (client)
+	transmitTimestamp := unixMillisecondsToNTPTimestamp(localStarted)
+	copy(request[40:48], transmitTimestamp[:])
+	if _, err := connection.Write(request); err != nil {
+		return ntpSample{}, fmt.Errorf("send NTP request: %w", err)
+	}
+	response := make([]byte, 512)
+	received, err := connection.Read(response)
+	anchor := time.Now()
+	if err != nil {
+		if ctx.Err() != nil {
+			return ntpSample{}, ctx.Err()
+		}
+		return ntpSample{}, fmt.Errorf("receive NTP response: %w", err)
+	}
+	if received < 48 {
+		return ntpSample{}, fmt.Errorf("short NTP response: %d bytes", received)
+	}
+	response = response[:received]
+	header := response[0]
+	leap := header >> 6
+	version := (header >> 3) & 0x07
+	mode := header & 0x07
+	stratum := response[1]
+	if leap == 3 || version < 3 || version > 4 || mode != 4 || stratum < 1 || stratum > 15 {
+		return ntpSample{}, errors.New("invalid NTP response header")
+	}
+	if !bytes.Equal(response[24:32], request[40:48]) {
+		return ntpSample{}, errors.New("NTP originate timestamp mismatch")
+	}
+
+	t1 := localStarted * nanosecondsPerMilli
+	elapsedNanos := anchor.Sub(started).Nanoseconds()
+	t4 := t1 + elapsedNanos
+	t2, err := ntpTimestampToUnixNanoseconds(response[32:40])
+	if err != nil {
+		return ntpSample{}, fmt.Errorf("decode NTP receive timestamp: %w", err)
+	}
+	t3, err := ntpTimestampToUnixNanoseconds(response[40:48])
+	if err != nil {
+		return ntpSample{}, fmt.Errorf("decode NTP transmit timestamp: %w", err)
+	}
+	if t3 < t2 {
+		return ntpSample{}, errors.New("NTP transmit time precedes receive time")
+	}
+	offsetNanos := ((t2 - t1) + (t3 - t4)) / 2
+	accurateAtAnchor := (t4 + offsetNanos) / nanosecondsPerMilli
+	networkDelay := elapsedNanos - (t3 - t2)
+	if networkDelay < 0 {
+		networkDelay = 0
+	}
+	return ntpSample{
+		server:           server,
+		anchor:           anchor,
+		accurateAtAnchor: accurateAtAnchor,
+		roundTripMS:      uint64((networkDelay + nanosecondsPerMilli - 1) / nanosecondsPerMilli),
+		offsetNanos:      offsetNanos,
+	}, nil
+}
+
+// responseServerTime accepts the URL-encoded CF response format and a small
+// JSON envelope for forward compatibility. A response header is also accepted
+// so Workers can add time calibration without changing their existing body.
+func responseServerTime(body []byte, headers http.Header) (int64, bool) {
+	if timestamp, ok := parseServerTimeValue(headers.Get(serverTimeHeader)); ok {
+		return timestamp, true
+	}
+	raw := strings.TrimSpace(string(body))
+	if raw == "" || strings.EqualFold(raw, "OK") {
+		return 0, false
+	}
+	if strings.HasPrefix(raw, "{") {
+		var envelope struct {
+			ServerTime json.RawMessage `json:"server_time"`
+		}
+		if json.Unmarshal(body, &envelope) == nil && len(envelope.ServerTime) > 0 {
+			var timestamp int64
+			if json.Unmarshal(envelope.ServerTime, &timestamp) == nil && timestamp > 0 {
+				return timestamp, true
+			}
+		}
+		return 0, false
+	}
+	values, err := url.ParseQuery(raw)
+	if err != nil {
+		return 0, false
+	}
+	return parseServerTimeValue(values.Get("server_time"))
+}
+
+func parseServerTimeValue(raw string) (int64, bool) {
+	timestamp, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	return timestamp, err == nil && timestamp > 0
+}

--- a/internal/cfprobe/clock_test.go
+++ b/internal/cfprobe/clock_test.go
@@ -1,0 +1,227 @@
+package cfprobe
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestServerCalibrationUsesRTTMidpointAndMonotonicAge(t *testing.T) {
+	anchor := time.Now()
+	serverTime := anchor.UnixMilli() + 500
+	calibration := newServerCalibration(serverTime, 80*time.Millisecond, anchor)
+	snapshot := calibration.snapshot(anchor.Add(20 * time.Millisecond))
+
+	if snapshot.AccurateTS == nil || *snapshot.AccurateTS != serverTime+60 {
+		t.Fatalf("AccurateTS = %v, want %d", snapshot.AccurateTS, serverTime+60)
+	}
+	if snapshot.OffsetMS == nil || *snapshot.OffsetMS != 540 {
+		t.Fatalf("OffsetMS = %v, want 540", snapshot.OffsetMS)
+	}
+	if snapshot.Source == nil || *snapshot.Source != "server" {
+		t.Fatalf("Source = %v, want server", snapshot.Source)
+	}
+	if snapshot.RoundTripMS == nil || *snapshot.RoundTripMS != 80 {
+		t.Fatalf("RoundTripMS = %v, want 80", snapshot.RoundTripMS)
+	}
+	if snapshot.SampleAgeMS == nil || *snapshot.SampleAgeMS != 20 {
+		t.Fatalf("SampleAgeMS = %v, want 20", snapshot.SampleAgeMS)
+	}
+}
+
+func TestNTPTimestampRoundTripPreservesUnixMilliseconds(t *testing.T) {
+	const unixMilliseconds = int64(1_754_300_060_123)
+	encoded := unixMillisecondsToNTPTimestamp(unixMilliseconds)
+	decoded, err := ntpTimestampToUnixNanoseconds(encoded[:])
+	if err != nil {
+		t.Fatalf("ntpTimestampToUnixNanoseconds() error = %v", err)
+	}
+	difference := decoded/nanosecondsPerMilli - unixMilliseconds
+	if difference < -1 || difference > 1 {
+		t.Fatalf("decoded difference = %dms, want within 1ms", difference)
+	}
+}
+
+func TestNTPClientUsesServerTimestamps(t *testing.T) {
+	server, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP() error = %v", err)
+	}
+	defer server.Close()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		request := make([]byte, 48)
+		_, peer, err := server.ReadFromUDP(request)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		accurate := time.Now().UnixMilli() + 250
+		stamp := unixMillisecondsToNTPTimestamp(accurate)
+		response := make([]byte, 48)
+		response[0] = 0x24 // leap=0, version=4, mode=4 (server)
+		response[1] = 1
+		copy(response[24:32], request[40:48])
+		copy(response[32:40], stamp[:])
+		copy(response[40:48], stamp[:])
+		_, err = server.WriteToUDP(response, peer)
+		serverErr <- err
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	sample, err := queryNTPAddress(ctx, "local-test", server.LocalAddr().(*net.UDPAddr))
+	if err != nil {
+		t.Fatalf("queryNTPAddress() error = %v", err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("test NTP server error = %v", err)
+	}
+	offsetMilliseconds := sample.offsetNanos / nanosecondsPerMilli
+	if offsetMilliseconds < 200 || offsetMilliseconds > 300 {
+		t.Fatalf("offset = %dms, want 200..300ms", offsetMilliseconds)
+	}
+	if sample.server != "local-test" {
+		t.Fatalf("server = %q, want local-test", sample.server)
+	}
+}
+
+func TestSelectMedianNTPSampleRejectsOutlierAndBreaksTieByRTT(t *testing.T) {
+	samples := []ntpSample{
+		{server: "low-outlier", offsetNanos: -1_000 * nanosecondsPerMilli, roundTripMS: 1},
+		{server: "near-slow", offsetNanos: 10 * nanosecondsPerMilli, roundTripMS: 20},
+		{server: "near-fast", offsetNanos: 12 * nanosecondsPerMilli, roundTripMS: 5},
+		{server: "high-outlier", offsetNanos: 1_000 * nanosecondsPerMilli, roundTripMS: 1},
+	}
+	selected := selectMedianNTPSample(samples)
+	if selected.server != "near-fast" {
+		t.Fatalf("selected server = %q, want near-fast", selected.server)
+	}
+}
+
+func TestCalibratedClockPrefersFreshNTPAndFallsBackToServer(t *testing.T) {
+	now := time.Now()
+	clock := calibratedClock{
+		ntp: &clockCalibration{
+			source:           "ntp:test",
+			anchor:           now,
+			accurateAtAnchor: now.UnixMilli() + 200,
+		},
+		server: &clockCalibration{
+			source:           "server",
+			anchor:           now,
+			accurateAtAnchor: now.UnixMilli() + 100,
+		},
+	}
+	snapshot := clock.snapshot(now.Add(time.Second))
+	if snapshot.Source == nil || *snapshot.Source != "ntp:test" {
+		t.Fatalf("fresh Source = %v, want ntp:test", snapshot.Source)
+	}
+
+	clock.ntp.anchor = now.Add(-maxCalibrationAge - time.Second)
+	snapshot = clock.snapshot(now.Add(time.Second))
+	if snapshot.Source == nil || *snapshot.Source != "server" {
+		t.Fatalf("fallback Source = %v, want server", snapshot.Source)
+	}
+}
+
+func TestNTPRefreshIsRateLimited(t *testing.T) {
+	now := time.Now()
+	clock := calibratedClock{}
+	if !clock.beginNTPRefresh(now) {
+		t.Fatal("first NTP refresh was not allowed")
+	}
+	if clock.beginNTPRefresh(now.Add(ntpRefreshInterval - time.Millisecond)) {
+		t.Fatal("NTP refresh inside interval was allowed")
+	}
+	if !clock.beginNTPRefresh(now.Add(ntpRefreshInterval)) {
+		t.Fatal("NTP refresh at interval boundary was not allowed")
+	}
+}
+
+func TestUncalibratedClockSerializesNullCalibrationFields(t *testing.T) {
+	snapshot := (&calibratedClock{}).snapshot(time.UnixMilli(1234))
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	want := `{"local_ts":1234,"accurate_ts":null,"offset_ms":null,"source":null,"round_trip_ms":null,"sample_age_ms":null}`
+	if string(encoded) != want {
+		t.Fatalf("encoded snapshot = %s, want %s", encoded, want)
+	}
+}
+
+func TestResponseServerTimeFormats(t *testing.T) {
+	const timestamp = int64(1_754_300_060_123)
+	tests := []struct {
+		name    string
+		body    string
+		headers http.Header
+	}{
+		{name: "form body", body: "server_time=1754300060123"},
+		{name: "form with config", body: "server_time=1754300060123&report_interval=60"},
+		{name: "json body", body: `{"server_time":1754300060123}`},
+		{name: "header", body: "OK", headers: http.Header{serverTimeHeader: []string{"1754300060123"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := responseServerTime([]byte(test.body), test.headers)
+			if !ok || got != timestamp {
+				t.Fatalf("responseServerTime() = (%d, %v), want (%d, true)", got, ok, timestamp)
+			}
+		})
+	}
+}
+
+func TestHandleReportResponseCalibratesServerTimeWithoutConfig(t *testing.T) {
+	agent := Agent{log: newLogger(false)}
+	started := time.Now()
+	completed := started.Add(80 * time.Millisecond)
+	agent.handleTimedReportResponse(
+		http.StatusOK,
+		[]byte("server_time=1754300060123"),
+		http.Header{},
+		started,
+		completed,
+	)
+	snapshot := agent.clock.snapshot(completed)
+	if snapshot.Source == nil || *snapshot.Source != "server" {
+		t.Fatalf("Source = %v, want server", snapshot.Source)
+	}
+	if snapshot.AccurateTS == nil || *snapshot.AccurateTS != 1_754_300_060_163 {
+		t.Fatalf("AccurateTS = %v, want 1754300060163", snapshot.AccurateTS)
+	}
+}
+
+func TestServerTimeCoexistsWithURLConfigResponse(t *testing.T) {
+	tmp := t.TempDir()
+	configFile := tmp + "/config.conf"
+	agent := Agent{
+		cfg: Config{
+			ServerID:       "sid",
+			Secret:         "secret",
+			WorkerURL:      "https://worker.example.com/report",
+			ReportInterval: 60,
+			ResetDay:       1,
+			ConfigMD5:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		paths: Paths{ConfigFile: configFile, TrafficFile: tmp + "/traffic.dat"},
+		log:   newLogger(false),
+	}
+	headers := http.Header{"X-Agent-Config-Md5": []string{"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}
+	body := []byte("server_time=1754300060123&collect_interval=0&report_interval=60&reset_day=1&schema_version=3&interface=")
+	started := time.Now()
+	agent.handleTimedReportResponse(http.StatusOK, body, headers, started, started.Add(20*time.Millisecond))
+
+	if agent.cfg.ConfigMD5 != "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" {
+		t.Fatalf("ConfigMD5 = %q", agent.cfg.ConfigMD5)
+	}
+	snapshot := agent.clock.snapshot(started.Add(20 * time.Millisecond))
+	if snapshot.Source == nil || *snapshot.Source != "server" {
+		t.Fatalf("Source = %v, want server", snapshot.Source)
+	}
+}

--- a/internal/cfprobe/clock_test.go
+++ b/internal/cfprobe/clock_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -126,6 +127,60 @@ func TestCalibratedClockPrefersFreshNTPAndFallsBackToServer(t *testing.T) {
 	snapshot = clock.snapshot(now.Add(time.Second))
 	if snapshot.Source == nil || *snapshot.Source != "server" {
 		t.Fatalf("fallback Source = %v, want server", snapshot.Source)
+	}
+}
+
+func TestCalibratedClockCorrectsSamplesCollectedBeforeCalibration(t *testing.T) {
+	anchor := time.Now()
+	clock := calibratedClock{
+		ntp: &clockCalibration{
+			source:           "ntp:test",
+			anchor:           anchor,
+			accurateAtAnchor: 1_000_000,
+		},
+	}
+
+	timestamp, ok := clock.timestamp(anchor.Add(-3 * time.Second))
+	if !ok {
+		t.Fatal("retroactive timestamp was not calibrated")
+	}
+	if timestamp != 997_000 {
+		t.Fatalf("timestamp = %d, want 997000", timestamp)
+	}
+
+	if timestamp, ok := clock.timestamp(anchor.Add(-maxCalibrationAge - time.Millisecond)); ok {
+		t.Fatalf("expired retroactive timestamp was calibrated as %d", timestamp)
+	}
+}
+
+func TestSamplesAndBootTimeUseCalibratedTimeline(t *testing.T) {
+	anchor := time.Now()
+	offset := int64(500)
+	agent := Agent{
+		clock: calibratedClock{
+			ntp: &clockCalibration{
+				source:           "ntp:test",
+				anchor:           anchor,
+				accurateAtAnchor: anchor.UnixMilli() + offset,
+			},
+		},
+		samples: []metricSample{{
+			at:      anchor.Add(-3 * time.Second),
+			metrics: map[string]any{"cpu": "1.00"},
+		}},
+	}
+
+	samples := agent.samplesForReport()
+	wantSampleTime := anchor.UnixMilli() + offset - 3_000
+	if got := samples[0]["ts"]; got != wantSampleTime {
+		t.Fatalf("samples[0].ts = %v, want %d", got, wantSampleTime)
+	}
+
+	localBootTime := anchor.UnixMilli() - int64(time.Hour/time.Millisecond)
+	metrics := agent.metricsForReport(Metrics{BootTime: strconv.FormatInt(localBootTime, 10)}, anchor)
+	wantBootTime := strconv.FormatInt(localBootTime+offset, 10)
+	if got := metrics["boot_time"]; got != wantBootTime {
+		t.Fatalf("metrics.boot_time = %v, want %s", got, wantBootTime)
 	}
 }
 


### PR DESCRIPTION
## 变更说明

  参考 `probe-rs` 的时间校准实现，为 CF Go Probe 增加独立时间校准与上报能力。

  ## 主要改动

  - 每 10 分钟并行查询以下 NTP 服务：
    - `time.cloudflare.com`
    - `time.google.com`
    - `time.nist.gov`
    - `ntp.aliyun.com`
  - 根据成功样本的时间偏差中位数选择校准源，降低单一异常源的影响。
  - 使用单调时钟维护校准锚点，不修改系统时间。
  - NTP 不可用时，支持使用 Worker 返回的 `server_time` 作为兜底。
  - 上报新增顶层 `time` 字段：
    - `local_ts`
    - `accurate_ts`
    - `offset_ms`
    - `source`
    - `round_trip_ms`
    - `sample_age_ms`
  - 使用校准时间生成 `samples[].ts`。
  - 使用当前校准偏差修正 `metrics.boot_time`。
  - 支持对 NTP 完成前已采集、仍待上报的样本进行单调时间回算。

  ## Worker 兼容方式

  Worker 可以通过以下任一方式返回 Unix 毫秒时间：

  ```text
  server_time=1754300060011

  {
    "server_time": 1754300060011
  }

  或者响应头：

  X-Server-Time: 1754300060011

  旧 Worker 不提供 server_time 时仍保持兼容，Agent 会优先使用公共 NTP。

  ## 时间戳行为

  - time.accurate_ts、samples[].ts 和 metrics.boot_time 使用校准时间。
  - time.local_ts 保留本地墙钟，用于计算和展示时间偏差。
  - 如果首次上报时 NTP 不可用且尚未获得 Worker 时间，该轮只能使用本地时间；获得 server_time 后下一轮开始校准。
  - 不修改系统时钟，也不影响现有采集和调度间隔。

  ## 验证

  已完成：

  - 新增 NTP 报文解析与本地 UDP NTP 服务测试
  - 多源中位数选源测试
  - NTP 优先、Worker 时间兜底测试
  - 校准过期和刷新限频测试
  - 历史待上报样本回溯校准测试
  - samples[].ts 与 metrics.boot_time 组包测试
  - go test
  - go vet ./...
  - go build ./...
  - Linux、FreeBSD、macOS、Windows 代表性目标交叉编译